### PR TITLE
Ignore ifxbilling models in django-author

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -304,3 +304,17 @@ class IFXMESSAGES():
     ACCOUNT_REQUEST_APPROVER_NOTIFICATION_MESSAGE = '{{project_name}}_account_request_approver_notification_message'
     ACCOUNT_REQUEST_COMPLETED_MESSAGE = '{{project_name}}_account_request_completed_message'
     ACCOUNT_REQUEST_COMPLETED_USER_NOTIFICATION_MESSAGE = '{{project_name}}_account_request_completed_user_notification_message'
+
+# Assuming ifxbilling is installed, these models should be ignored by the django-author pre-save
+# so that author values can be directly set
+AUTHOR_IGNORE_MODELS = [
+    'ifxbilling.BillingRecord',
+    'ifxbilling.Transaction',
+]
+
+AUTHOR_IGNORE_MODELS = [
+    'ifxbilling.BillingRecord',
+    'ifxbilling.Transaction',
+]
+
+


### PR DESCRIPTION
If ifxbilling is used, these models should be ignored by the django-author

pre-save signal so that author can be directly set.  Needed so that fiine
user can author on behalf of lab admins, etc. from fiine.